### PR TITLE
Allow path to  to be set via env variable

### DIFF
--- a/lib/view_data/pg/settings.rb
+++ b/lib/view_data/pg/settings.rb
@@ -2,7 +2,7 @@ module ViewData
   module PG
     class Settings < MessageStore::Postgres::Settings
       def self.data_source
-        'settings/view_data_pg.json'
+        ENV['VIEW_DATA_SETTINGS_PATH'] || 'settings/view_data_pg.json'
       end
     end
   end

--- a/test/automated/settings/default_path.rb
+++ b/test/automated/settings/default_path.rb
@@ -1,0 +1,19 @@
+require_relative '../automated_init'
+
+context "Settings" do
+  context "Default Path" do
+    prior_default_settings_path = ENV['VIEW_DATA_SETTINGS_PATH']
+
+    overridden_path = 'some_path'
+    ENV['VIEW_DATA_SETTINGS_PATH'] = overridden_path
+
+    settings_path = ViewData::PG::Settings.data_source
+
+    test "Overridden by VIEW_DATA_SETTINGS_PATH environment variable" do
+      assert(settings_path == overridden_path)
+    end
+
+    ENV['VIEW_DATA_SETTINGS_PATH'] = prior_default_settings_path
+  end
+end
+


### PR DESCRIPTION
Similar to message-store-postgres, the default path to the settings file can be changed by setting the `VIEW_DATA_SETTINGS_PATH` environment variable.